### PR TITLE
fixed name of configdestLog

### DIFF
--- a/etc/calamares/branding/xerolinux/finishedq.qml
+++ b/etc/calamares/branding/xerolinux/finishedq.qml
@@ -22,7 +22,7 @@ Page {
 
     id: finished
     // needs to come from umount.conf
-    property var configdestLog: "/var/log/installation.log"
+    property var configdestLog: "/var/log/Calamares.log"
 
     width: parent.width
     height: parent.height


### PR DESCRIPTION
The file copied in the target system is "Calamares.log", not "installation.log"